### PR TITLE
fix: Implement lazy initialization for Supabase client to fix build e…

### DIFF
--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,21 +1,45 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-// Get environment variables
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+let supabaseInstance: SupabaseClient | null = null;
 
-// Validate environment variables are present
-if (!supabaseUrl) {
-  throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable');
+/**
+ * Get or create the Supabase client instance
+ * Uses lazy initialization to avoid build-time errors
+ */
+function getSupabaseClient(): SupabaseClient {
+  // Return existing instance if available
+  if (supabaseInstance) {
+    return supabaseInstance;
+  }
+
+  // Get environment variables
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  // Validate environment variables are present
+  if (!supabaseUrl) {
+    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable');
+  }
+
+  if (!supabaseAnonKey) {
+    throw new Error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable');
+  }
+
+  // Create and cache the Supabase client
+  supabaseInstance = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: false, // We don't need session persistence for form submissions
+    },
+  });
+
+  return supabaseInstance;
 }
 
-if (!supabaseAnonKey) {
-  throw new Error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable');
-}
-
-// Create and export the Supabase client
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    persistSession: false, // We don't need session persistence for form submissions
+// Create a proxy that lazily initializes the client
+export const supabase = new Proxy({} as SupabaseClient, {
+  get(_target, prop) {
+    const client = getSupabaseClient();
+    const value = client[prop as keyof SupabaseClient];
+    return typeof value === 'function' ? value.bind(client) : value;
   },
 }); 


### PR DESCRIPTION
…rrors

Problem: Next.js build was failing with "Missing NEXT_PUBLIC_SUPABASE_URL" error during the build process when collecting page data for API routes.

Solution: Converted Supabase client initialization from eager to lazy using a Proxy pattern. The client is now only initialized when first accessed at runtime, not at module import time.

Changes:
- Wrapped getSupabaseClient() in a Proxy to defer initialization
- Moved from direct createClient() call to lazy getter pattern
- Maintains backward compatibility with existing `supabase` export

This allows Next.js build to succeed without requiring environment variables during the build phase while still validating them at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)