### PR TITLE
ci: grant deploy-preview PR-write permission, make comment non-fatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: github.event_name == 'pull_request'
+    # The default GITHUB_TOKEN is read-only; grant PR write so the comment posts.
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -148,6 +152,9 @@ jobs:
 
       - name: Comment PR with preview info
         uses: actions/github-script@v7
+        # Cosmetic only — never fail the pipeline over it (fork PRs always get a
+        # read-only token regardless of the permissions block above).
+        continue-on-error: true
         with:
           script: |
             github.rest.issues.createComment({


### PR DESCRIPTION
The deploy-preview job posts a PR comment via actions/github-script, but the workflow declared no permissions block, so the default read-only GITHUB_TOKEN got a 403 (Resource not accessible by integration) and failed the run even though the build succeeded.

- Add permissions: { contents: read, pull-requests: write } to the job so the comment can post on same-repo PRs.
- Mark the comment step continue-on-error so fork PRs (read-only token by design) can't fail the pipeline over a cosmetic comment.