### PR TITLE
Update live-in maids FAQ wording per revised FAQ schema

### DIFF
--- a/app/cities/bangalore/live-in-maids/page.tsx
+++ b/app/cities/bangalore/live-in-maids/page.tsx
@@ -165,7 +165,7 @@ export default async function BangaloreLiveInMaidsPage() {
       answer: "In most cases, a verified live-in maid is placed within 24–72 hours, depending on your requirements, preferred skills, location, and helper availability. Once we understand your needs, we shortlist suitable background-verified profiles, arrange interviews, and help you onboard the selected helper as quickly as possible. Our goal is to make the hiring process smooth, efficient, and hassle-free."
     },
     {
-      question: "Do live-in helpers speak Kannada or Hindi?",
+      question: "Do live-in maids speak Kannada or Hindi?",
       answer: "Yes. We match helpers based on your language preference, including Kannada, Hindi, and English, to help ensure smooth communication and a comfortable experience for your family."
     },
     {


### PR DESCRIPTION
Revised FAQ CSV (15 Jun 2026): Q7 question reworded 'live-in helpers' ->
'live-in maids' for consistency. The shared faqs array feeds both the FAQPage JSON-LD (FAQSchema) and the visible FAQAccordion, so both update.